### PR TITLE
Get file links going to proper /data url

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -129,7 +129,7 @@ block content
               | Documentation
             ul#menu3.dropdown-menu(aria-labelledby="drop3")
               li
-                a(href="/files/Manual-for-QC-of-Glider-Data_05_09_16.pdf", target="_blank").
+                a(href="files/Manual-for-QC-of-Glider-Data_05_09_16.pdf", target="_blank").
                   Manual for Quality Control of Temperature and Salinity Data
                   Observations from Gliders
                 p.
@@ -147,14 +147,14 @@ block content
                   GliderDAC\.
               li.divider(role="separator")
               li
-                a(href="/files/IOOS_National_Glider_Data_Assembly_CenterSIF.pdf", target="_blank").
+                a(href="files/IOOS_National_Glider_Data_Assembly_CenterSIF.pdf", target="_blank").
                   NCEI Submission Information Form for the IOOS National Glider
                   Data Assembly Center
                 p.
                   Describes process used to establish archiving of GliderDAC data with NCEI
               li.divider(role="separator")
               li
-                a(href="/files/natl_glider_ntwrk_plan_final.pdf", target="_blank").
+                a(href="files/natl_glider_ntwrk_plan_final.pdf", target="_blank").
                   IOOS Underwater Glider Network Plan
                 p.
                   Strategy for using underwater gliders as part of a larger
@@ -167,7 +167,7 @@ block content
                 p Metadata, Archiving and Community Tools
                   br
                   br
-                  a(href="/files/DAC-Webinar-20170406.ppt", target="_blank") [accompanying slides]
+                  a(href="files/DAC-Webinar-20170406.ppt", target="_blank") [accompanying slides]
 
       .col-sm-6.col-md-3
         ul.nav.nav-pills.glider-resources


### PR DESCRIPTION
With the leading / taken off of /files, it correctly goes to the /data/files url and the files load.
![image](https://user-images.githubusercontent.com/9978238/37657098-683272d0-2c20-11e8-8196-3c25e614acc7.png)
