### PR TITLE
Update links https

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -81,7 +81,7 @@ block content
                 p Summary of IOOS glider and AUV activities
               li.divider(role="separator")
               li
-                a(href="https://www.iooc.us/activities/task-teams/glider-tt/", target="_blank")
+                a(href="https://iooc.us/task-teams/glider/", target="_blank")
                   | IOOC Glider Task Team
                 p.
                   The goals of the Interagency Ocean Observation Committee

--- a/views/index.jade
+++ b/views/index.jade
@@ -121,7 +121,7 @@ block content
                   The THREDDS Data Server (TDS) is a web server that provides metadata and data access to all GliderDAC datasets, using a variety of remote data access protocols.
               li.divider(role="separator")
               li
-                a(href="https://data.nodc.noaa.gov/geoportal/rest/find/document?searchText=NGDAC&start=1&max=25&contentOption=intersecting&f=searchPage&dojo.preventCache=1452007401768", target="_blank") NCEI Glider Archive Data
+                a(href="https://www.ncei.noaa.gov/metadata/geoportal/#searchPanel?filter=NGDAC", target="_blank") NCEI Glider Archive Data
                 p.
                   NCEI archives data and metadata independently of the original
                   data providers so that it is available for use by future

--- a/views/index.jade
+++ b/views/index.jade
@@ -35,34 +35,34 @@ block content
               |  Gulf of Mexico
             |  (GCOOS),
 
-            a(href="http://sccoos.org/" , target="_blank")
+            a(href="https://sccoos.org/" , target="_blank")
               |  Southern California
             |  (SCCOOS),
 
-            a(href="http://nanoos.org/" , target="_blank")
+            a(href="https://nanoos.org/" , target="_blank")
               |  Northern Pacific
             |  (NANOOS),
 
-            a(href="http://cencoos.org/" , target="_blank")
+            a(href="https://cencoos.org/" , target="_blank")
               |  Central and Northern California
             |  (CeNCOOS),
 
-            a(href="http://glos.us/" , target="_blank")
+            a(href="https://glos.us/" , target="_blank")
               |  Great Lakes
             |  (GLOS),
 
-            a(href="http://maracoos.org/" , target="_blank")
+            a(href="https://maracoos.org/" , target="_blank")
               |  Mid-Atlantic
             |  (MARACOOS), and the
 
-            a(href="http://www.aoml.noaa.gov/", target="_blank")
+            a(href="https://www.aoml.noaa.gov/", target="_blank")
               |  Atlantic Oceanographic and Meteorological Lab
 
             |  (AOML). The gliders displayed have been funded by U.S. IOOS, NOAA,
             | ONR, NSF, EPA, various universities, state agencies and industries.
     .row
       .col-md-12
-        a(href="http://gliders.ioos.us/map/", target="_blank")
+        a(href="https://gliders.ioos.us/map/", target="_blank")
           #helper-overlay
             p Click here to see the map
           img.img-responsive(src="/images/ioos-map-screen-capture.png", alt="IOOS Gliders Map screen capture")
@@ -81,7 +81,7 @@ block content
                 p Summary of IOOS glider and AUV activities
               li.divider(role="separator")
               li
-                a(href="http://www.iooc.us/activities/task-teams/glider-tt/", target="_blank")
+                a(href="https://www.iooc.us/activities/task-teams/glider-tt/", target="_blank")
                   | IOOC Glider Task Team
                 p.
                   The goals of the Interagency Ocean Observation Committee
@@ -110,7 +110,7 @@ block content
                   association from 2008 to 2014
               li.divider(role="separator")
               li
-                a(href="http://data.ioos.us/gliders/erddap/index.html", target="_blank") ERDDAP Catalog
+                a(href="https://data.ioos.us/gliders/erddap/index.html", target="_blank") ERDDAP Catalog
                 p.
                   The ERDDAP Catalog provides direct access to all GliderDAC
                   datasets and allows users to make maps and graphs.
@@ -121,7 +121,7 @@ block content
                   The THREDDS Data Server (TDS) is a web server that provides metadata and data access to all GliderDAC datasets, using a variety of remote data access protocols.
               li.divider(role="separator")
               li
-                a(href="http://data.nodc.noaa.gov/geoportal/rest/find/document?searchText=NGDAC&start=1&max=25&contentOption=intersecting&f=searchPage&dojo.preventCache=1452007401768", target="_blank") NCEI Glider Archive Data
+                a(href="https://data.nodc.noaa.gov/geoportal/rest/find/document?searchText=NGDAC&start=1&max=25&contentOption=intersecting&f=searchPage&dojo.preventCache=1452007401768", target="_blank") NCEI Glider Archive Data
                 p.
                   NCEI archives data and metadata independently of the original
                   data providers so that it is available for use by future
@@ -197,7 +197,7 @@ block content
                   GliderDAC
               li.divider(role="separator")
               li
-                a(href="http://gliders.ioos.us/status", target="_blank").
+                a(href="https://gliders.ioos.us/status", target="_blank").
                   GliderDAC Submission Status Page
                 p.
                   Web-based tool for tracking the submission of glider data to


### PR DESCRIPTION
Updates all the HTTP links to their secure HTTPS counterparts. 

Fixed broken links
- https://iooc.us/task-teams/glider/
- https://www.ncei.noaa.gov/metadata/geoportal/#searchPanel?filter=NGDAC